### PR TITLE
fix: make identity_attributes/source_path_attributes classmethods

### DIFF
--- a/src/snakemake_software_deployment_plugin_envmodules/__init__.py
+++ b/src/snakemake_software_deployment_plugin_envmodules/__init__.py
@@ -19,11 +19,13 @@ class EnvSpec(EnvSpecBase):
         super().__init__()
         self.names: tuple[str, ...] = tuple(names)
 
-    def identity_attributes(self) -> Iterable[str]:
+    @classmethod
+    def identity_attributes(cls) -> Iterable[str]:
         # The identity of the env spec is given by the names of the modules.
         yield "names"
 
-    def source_path_attributes(self) -> Iterable[str]:
+    @classmethod
+    def source_path_attributes(cls) -> Iterable[str]:
         # no paths involved here
         return ()
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,4 +1,6 @@
+import hashlib
 import os
+from types import SimpleNamespace
 from typing import Optional, Type
 from snakemake_interface_software_deployment_plugins import EnvBase, EnvSpecBase
 from snakemake_interface_software_deployment_plugins.tests import (
@@ -44,3 +46,95 @@ class Test(TestSoftwareDeploymentBase):
     def get_test_cmd(self) -> str:
         # Return a command that should be executable without error in the environment
         return "somecmd"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for EnvSpec and the pure Env methods.
+#
+# These raise test coverage and guard the fix that made
+# identity_attributes / source_path_attributes classmethods (so that EnvSpec is
+# hashable and usable as a dict key, which the software-deployment manager
+# relies on for its specs_to_envs cache).
+# ---------------------------------------------------------------------------
+
+
+def _env_with_spec(spec):
+    """An Env-like object with only `.spec` set.
+
+    Env.__post_init__ runs check(), which needs the `module` command, so we
+    bypass construction and exercise only methods that depend on self.spec.
+    """
+    return SimpleNamespace(spec=spec)
+
+
+def _spec(*names):
+    """Construct an EnvSpec the way the directive factory does (with technical_init).
+
+    technical_init() is required before hashing/equality, because EnvSpecBase.__hash__
+    reads managed attributes (e.g. self.kind) that it sets.
+    """
+    spec = EnvSpec(*names)
+    spec.technical_init()
+    return spec
+
+
+def test_envspec_stores_names_as_tuple():
+    assert _spec("bwa", "samtools").names == ("bwa", "samtools")
+
+
+def test_envspec_str_is_comma_joined():
+    assert str(_spec("bwa", "samtools")) == "bwa,samtools"
+    assert str(_spec("bwa")) == "bwa"
+
+
+def test_identity_attributes_yields_names():
+    # classmethod: callable on the class itself
+    assert list(EnvSpec.identity_attributes()) == ["names"]
+
+
+def test_source_path_attributes_is_empty():
+    assert list(EnvSpec.source_path_attributes()) == []
+
+
+def test_envspec_hash_and_equality_use_names():
+    # Regression guard: __hash__ resolves through cls.identity_attributes(),
+    # which only works because identity_attributes is now a @classmethod.
+    a = _spec("bwa", "samtools")
+    b = _spec("bwa", "samtools")
+    c = _spec("bwa")
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != c
+    assert hash(a) != hash(c)
+
+
+def test_envspec_is_usable_as_dict_key():
+    # The original crash: hashing an envmodules spec raised TypeError, so it
+    # could not be used as a dict key (e.g. in specs_to_envs).
+    spec = _spec("bwa")
+    lookup = _spec("bwa")
+    assert {spec: "env"}[lookup] == "env"
+
+
+def test_env_decorate_shellcmd_loads_modules():
+    env = _env_with_spec(_spec("bwa", "samtools"))
+    assert Env.decorate_shellcmd(env, "echo hi") == (
+        "module purge && module load bwa samtools && echo hi"
+    )
+
+
+def test_env_decorate_shellcmd_quotes_unsafe_names():
+    env = _env_with_spec(_spec("name with space"))
+    assert "module load 'name with space'" in Env.decorate_shellcmd(env, "cmd")
+
+
+def test_env_record_hash_uses_names():
+    env = _env_with_spec(_spec("bwa", "samtools"))
+    h = hashlib.sha256()
+    Env.record_hash(env, h)
+    assert h.hexdigest() == hashlib.sha256(b"bwa,samtools").hexdigest()
+
+
+def test_env_report_software_is_empty():
+    env = _env_with_spec(_spec("bwa"))
+    assert list(Env.report_software(env)) == []

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -133,8 +133,3 @@ def test_env_record_hash_uses_names():
     h = hashlib.sha256()
     Env.record_hash(env, h)
     assert h.hexdigest() == hashlib.sha256(b"bwa,samtools").hexdigest()
-
-
-def test_env_report_software_is_empty():
-    env = _env_with_spec(_spec("bwa"))
-    assert list(Env.report_software(env)) == []


### PR DESCRIPTION
## Problem

`EnvSpec.identity_attributes` and `EnvSpec.source_path_attributes` are defined as instance methods (`self`), but the interface base (`snakemake_interface_software_deployment_plugins.EnvSpecBase`) and the sibling plugins (conda, container) declare them as `@classmethod` (`cls`).

## Impact

`EnvSpecBase.__hash__` -> `managed_identity_attributes()` (a classmethod) calls `cls.identity_attributes()`. Because this plugin's `identity_attributes` is an instance method, that call raises:

```
TypeError: EnvSpec.identity_attributes() missing 1 required positional argument: 'self'
```

So every envmodules spec is **unhashable**. Anywhere a spec is used as a dict key or set member it crashes — in particular `SoftwareDeploymentManager.get_env()` does `if env_spec in self.specs_to_envs:`, which hashes the spec. This breaks standalone `envmodules(...)` usage and the fallback chain `envmodules(...) or conda(...)` (the headline composition form).

## Fix

Make both methods `@classmethod`, matching the interface and the other plugins:

```python
@classmethod
def identity_attributes(cls) -> Iterable[str]:
    yield "names"

@classmethod
def source_path_attributes(cls) -> Iterable[str]:
    return ()
```

Neither body uses `self`, so this is a drop-in fix.

## Verification

After the change, envmodules specs are hashable (`hash(spec)` succeeds) and `get_env()` no longer crashes on the fallback path.

Context: snakemake/snakemake#4209; related interface fix: snakemake/snakemake-interface-software-deployment-plugins#58.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment identity and source-path attribute handling, making environment identification and hashing more consistent.
  * Fixed shell command generation to correctly load and quote module names containing unsafe characters (e.g., spaces).
  * Ensured environment specifications implement correct equality and hashing, including reliable dictionary-key usage.
* **Tests**
  * Added unit tests to cover environment identity attributes, string formatting, hashing/record hashing, and decorated shell command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->